### PR TITLE
Add an input for `ShipSpecialService` if its sent in shipment payload

### DIFF
--- a/lib/documents/shipment_order.rb
+++ b/lib/documents/shipment_order.rb
@@ -38,6 +38,7 @@ module Documents
             xml.BillTo(bill_to_hash)
 
             xml.ShipSpecialService('SIGNATURE') if @shipment['signature_requested']
+            xml.ShipSpecialService(@shipment['special_service']) if @shipment['special_service']
             xml.Notes('NoteType' => @shipment['note_type'].to_s, 'NoteValue' => @shipment['note_value'].to_s)
 
             xml.ValueAddedService(


### PR DESCRIPTION
- A new feature of QL is setting DDP and DDU (duties paid and unpaid)
separately from the carrier and service level. This isn't currently
documented in the integration guide but one of the managers from QL
verified that this feature exists and would be added in the guide in the
future.