### PR TITLE
Add `/get_errors` endpoint

### DIFF
--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -228,10 +228,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
         message  = "Got error code #{msg['error_code']}"
       end
 
-      code = 200
-    rescue => e
-      message  = e.message
-      code     = 500
+      code = 500
     end
 
     result code, message

--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -218,6 +218,25 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
     result code, message
   end
 
+  post '/get_errors' do
+    begin
+      msg    = @payload['message']
+      type   = msg['document_type']
+
+      if type == 'error'
+        add_object(:error, msg)
+        message  = "Got error code #{msg['error_code']}"
+      end
+
+      code = 200
+    rescue => e
+      message  = e.message
+      code     = 500
+    end
+
+    result code, message
+  end
+
   def outgoing_queue
     @config['ql_outgoing_queue']
   end


### PR DESCRIPTION
- Return an error message as an error object back to flowlink so that it
doesn't get lost in the messages queue