### PR TITLE
Test and update delete_message param to account for integers

### DIFF
--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -171,7 +171,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
         message  = "Got Shipment for #{msg['document_name']}"
       end
 
-      unless @config['delete_message'] == '0'
+      unless @config['delete_message'] == '0' || @config['delete_message'] == 0
         MessageDeleter.new(@config, @payload).delete_message if msg['receipt_handle']
       end
 
@@ -198,7 +198,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
         message  = "Got inventory for #{msg['document_name']}"
       end
 
-      unless @config['delete_message'] == '0'
+      unless @config['delete_message'] == '0' || @config['delete_message'] == 0
         MessageDeleter.new(@config, @payload).delete_message if msg['receipt_handle']
       end
 
@@ -223,7 +223,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
         message  = "Got Shipment Cancellation for #{msg['document_name']}"
       end
 
-      unless @config['delete_message'] == '0'
+      unless @config['delete_message'] == '0' || @config['delete_message'] == 0
         MessageDeleter.new(@config, @payload).delete_message if msg['receipt_handle']
       end
 
@@ -265,7 +265,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
         message  = "Got RMAResult for #{msg['document_name']}"
       end
 
-      unless @config['delete_message'] == '0'
+      unless @config['delete_message'] == '0' || @config['delete_message'] == 0
         MessageDeleter.new(@config, @payload).delete_message(config, payload) if msg['receipt_handle']
       end
 

--- a/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_delete_messages_by_default/returns_200_and_shipments_object.yml
+++ b/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_delete_messages_by_default/returns_200_and_shipments_object.yml
@@ -1,0 +1,515 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153447Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=8367a9daae9d860f74f855ad0c6d2f643597c3aeb75840974571fda16b723091
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - bcec980d-fc7e-5dad-a26c-cdc281a9df4b
+      Date:
+      - Thu, 15 Aug 2019 15:34:47 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1531'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c9e80ebc-7b96-4810-aba5-d129387d1a00</MessageId><ReceiptHandle>AQEBEBOhg5oAMnBO8skFdf3n1numftIaIiag3KjGQOWsX/AmApdad9YVIS4UCZEOcPuMbl9v5JMR/2O7ER08s5mrB+Vup4+Hi7fIVz1DT3wVrS1LUXAscPDzN3RPWw1XDZL/uyPtqO23bD4IDSKt9hJxY8lgzmpHhScBo4Sw4cFnJPIjO/F1z+XvtY+Kpbuywec/hZkjXj+RUt4+/XCs9IE+x4Iq5yf+IazbaS07qzyaeTGsQQR5kdKpwKBIIQpAQ8Lh2Fgz7gCfP1yiYDfE5kOlhkzI6NcAIPsceCnyEsQ5O4za49QE2AtZwrjW2aCMsHW1S407JDeVaOsFBnGYu9ofa3E0hlra+fJjcNIhUmYdRqpjtbf0TtWrpAxPhvI0N7kOWn5f3ieuSLiqj3dUg5CdXQ==</ReceiptHandle><MD5OfBody>a9dd99bd8641a19b3df3b90bf410d277</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;6b9f2760-9759-4057-8aa0-da00bea51af8&quot; MessageDate=&quot;2019-08-12T16:12:48.0434895Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>bcec980d-fc7e-5dad-a26c-cdc281a9df4b</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:47 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153447Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=8367a9daae9d860f74f855ad0c6d2f643597c3aeb75840974571fda16b723091
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 6021ce1d-fb3b-5fe3-adfb-9bd286e3f515
+      Date:
+      - Thu, 15 Aug 2019 15:34:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1514'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>0146b7fb-269b-4869-b76b-cf7fc5b15213</MessageId><ReceiptHandle>AQEBL4ctKV+pxNn+WaCv/d60yXwhbK8Ukq1My60q6E3Bx+APl+BhUFZllic4tdev2bNbuutfbZZifDAzdtJvg2vtRMzx/a3LNJV9Vs/8UpNs8nrNGwlk6C1PtWImM88Pq5hZQMW5qT7i6q5uzdmaiAkjNHRasVCtv3F1qBF94AjWoHJW7/1Hz6KUg/zIhlHUW5HCfcM3oxtWuD5eg6J0JSJPfMMlmVLR486o5cbHONHxhiUOA6QOyQSMW97rgJNtu+0fHdcy254iKFes5EY9sSLB0QgRj3UcVdRIbygVEhQwj4IeJqyS9Robf1snI5B/eBmOxwAeF2NCHrgHtv4K4VC8Xnh61roYLYy579Shu8uccobFhXWp5YHEr0i3e/Ct5XbXgIucgmkl0buCoxNXWU3Pzg==</ReceiptHandle><MD5OfBody>03d64ef67c619693776721d2d0b6ad29</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;e80c469d-e292-4868-9764-d13ef6c85c21&quot; MessageDate=&quot;2019-08-12T16:11:46.5609295Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192155_20190812_121140070.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>6021ce1d-fb3b-5fe3-adfb-9bd286e3f515</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:48 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153448Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=e59bba839f46d9e8c48d73eda6c5ef0171e25e67c94be1e8701cf9ad1b5172d8
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - ae9145ba-167e-56e1-8139-10756ba6ebbd
+      Date:
+      - Thu, 15 Aug 2019 15:34:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEBaK7sxfrBkk9ZJPbl0AO0b7BBN1BaFqmLrma/zGHBSD/e3XZ+cQ3qUwKCz+DlU+ZuoHaCMT5sP7GRlbK89dFM8WCV9SQAWISfNEXPbSeYm52gtL5PbWC5Q3cTO6pXJsDOV0cKFB43ER0OM2m7lzfcuKuSeg/RHz+zIxmDxAIfl1c+h3+DoSb4rCsIJnYIuIpHeigrm+A6AthIFSHIMXTtxRIyeS9OrGQJFGdB6jTwkuJUBIcYJa2DUgcMIgC13+8tONNhvDNyynImtmEisSF0g5hmVa/g4gQxTs6/EJxxLJTZKmlo/DKiagGMokeDGxGoZXg5sfjHe7LkpY+WbFVHYbTqhcAne+ACWkuTTvgTpYGdSDep1HuoL9SSc7qapTYQ1xy9vm/P7usB+T9RlZrZeg==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEBrKjnnrU/LsTa4tc4Hl87nutC15vkOI5QWIQnq9kz/VUIkqrs4ry5YC3NzbQkecc32LEP9hPZhB9PceJb3L1SgPlvSAiCHEmdRgC1wbcBy9ZX3AdrGr0otD8swlymsiyqxHxW5poXDWhe5Ayk5sqg9KwSShRJP/yFWSy4uiTFeARpGZYAVc0TadV+TWF1/R8tSXHVZWDEu/anEb5rZlCsykWmeJ18A8GEttI+WMhXBizeSggRoOYLrVpw2PtYKq2NGVndv9Jv/o/cEZE11Vnfa0SrK7SoiWAxxsNTyM0TYh5YTLYljXwef7WwPWlAXZxlffTaQKl+PCBRBfdhgUNc/tDaArKcEDQBonOOsm50kJ7WG2BGj4vsikBB7S7K9i/rQn2K3EB6tZTnGOud0sBSRw==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>ae9145ba-167e-56e1-8139-10756ba6ebbd</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:48 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153448Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=e59bba839f46d9e8c48d73eda6c5ef0171e25e67c94be1e8701cf9ad1b5172d8
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 7518241b-de60-5b8c-8823-71d4a3b8ba95
+      Date:
+      - Thu, 15 Aug 2019 15:34:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEBCUDpPpEL2MJl80wAi6zJet+TUZLChJEXtane7wLyOFpUpwypE0/TJyHYja/d2fW4G3jyaPZC2UAzPk+HuRyjetxIoHafkgrDGDd86kIWNXJX+8GVZeweLKbwHlywKduEhDV81+54Rbt0l1XTNWSkewhRmZ7K+Yc3r/sUw35C9ano8UwkEZ41jTI08pY0XI+kt7IyxthYTuwKwasvIOUIZgIC1l8ZFrjexUqAqY2GU3n8QHchhFGXr9bMJRB5hStkVoPTqNlB1nJXKpsWC62d40WAB5i/lrHQHWHI+pwgwQjpjVGS3ZE6HfUtifLJ8HzvHoBPJkwVQPByNunSt9+BLWidSsfu2OEDiO5PFlsGKeNns8L8IDQGJms7GKUwHb6h3/Is8SdCxHATPcsoWTmFeA==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>7518241b-de60-5b8c-8823-71d4a3b8ba95</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:49 GMT
+- request:
+    method: get
+    uri: https://<ql_incoming_bucket>.s3.amazonaws.com/SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-s3/1.21.0
+      Host:
+      - "<ql_incoming_bucket>.s3.amazonaws.com"
+      X-Amz-Date:
+      - 20190815T153449Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=54206b11066747e260e76f50eb9763ba2388fe85187ee8435e19abdc1138ee31
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - oNYLkXG/OAFYS4yTKO3TzBa542wz3EDKLG7BwREifknkRLMbAfoGbrIixDDNtbyl68/dIMbU8Hk=
+      X-Amz-Request-Id:
+      - 128737C307F0750D
+      Date:
+      - Thu, 15 Aug 2019 15:34:50 GMT
+      Last-Modified:
+      - Mon, 12 Aug 2019 16:12:48 GMT
+      X-Amz-Expiration:
+      - expiry-date="Tue, 27 Aug 2019 00:00:00 GMT", rule-id="OTZjMjUwZTctMDJiYi00NWFkLTgxNGYtM2UxYzQ1MzNhMGVl"
+      Etag:
+      - '"4c126b4afdc055f277abb30a776b9eb7"'
+      X-Amz-Meta-Title:
+      - SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '827'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<SOResult xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ClientID=\"<client_id>\"
+        BusinessUnit=\"<client_id>\" OrderNumber=\"R712449277-H36307541617\" DateShipped=\"2019-08-05T14:07:00Z\"
+        FreightCost=\"0\" CartonCount=\"1\" Warehouse=\"DVN\" xmlns=\"http://schemas.quiettechnology.com/V2/SOResultDocument.xsd\">\r\n
+        \ <Line Line=\"1\" ItemNumber=\"M02B42-BNC-M\" Quantity=\"1\" ExceptionCode=\"\"
+        Tax=\"0\" Total=\"37.0000\" SubstitutedItem=\"\" />\r\n  <Carton CartonId=\"S99R712449277-H36307541617-2019081418\"
+        TrackingId=\"1Z1006881680002019081418\" Carrier=\"USPS\" CartonNumber=\"1\"
+        ServiceLevel=\"FIRST\" Weight=\"1.2\" FreightCost=\"3.05\" HandlingFee=\"0\"
+        Surcharge=\"0\">\r\n    <Content Line=\"1\" ItemNumber=\"M02B42-BNC-M\" Quantity=\"1\"
+        />\r\n  </Carton>\r\n  <Extension />\r\n</SOResult>"
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:49 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=DeleteMessage&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&ReceiptHandle=AQEBEBOhg5oAMnBO8skFdf3n1numftIaIiag3KjGQOWsX%2FAmApdad9YVIS4UCZEOcPuMbl9v5JMR%2F2O7ER08s5mrB%2BVup4%2BHi7fIVz1DT3wVrS1LUXAscPDzN3RPWw1XDZL%2FuyPtqO23bD4IDSKt9hJxY8lgzmpHhScBo4Sw4cFnJPIjO%2FF1z%2BXvtY%2BKpbuywec%2FhZkjXj%2BRUt4%2B%2FXCs9IE%2Bx4Iq5yf%2BIazbaS07qzyaeTGsQQR5kdKpwKBIIQpAQ8Lh2Fgz7gCfP1yiYDfE5kOlhkzI6NcAIPsceCnyEsQ5O4za49QE2AtZwrjW2aCMsHW1S407JDeVaOsFBnGYu9ofa3E0hlra%2BfJjcNIhUmYdRqpjtbf0TtWrpAxPhvI0N7kOWn5f3ieuSLiqj3dUg5CdXQ%3D%3D&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153449Z
+      X-Amz-Content-Sha256:
+      - f31d75f3441a9b51c7b52d3d59f68c45a4b2e18078189b11444fc843fa9afb11
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=a4a4a414faef0c4485a390c935e31eb82ed1c82ce8404799626921516aae6f30
+      Content-Length:
+      - '595'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 8771e18e-7d42-57bd-81b9-b4410098d008
+      Date:
+      - Thu, 15 Aug 2019 15:34:50 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '215'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><DeleteMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>8771e18e-7d42-57bd-81b9-b4410098d008</RequestId></ResponseMetadata></DeleteMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:34:50 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153520Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=5ea419fade9dd31d07cdf2d390288bc85e41369755ba44e2e36a901030b2cd4a
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 42fd23bc-6706-5d6c-bfc3-76731afe6c83
+      Date:
+      - Thu, 15 Aug 2019 15:35:20 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEBq0fGBQTK6vspsDVzzVWKk/BRmh644DfUEaVRMoeYebkDRn9JT0XL/pt/cpNL+6D6Xexb4VLC8AY+iiqUodATvyJv3H3k/OySZr5SbGCN+MphmZxy6l/gjBtTgiMbDl3c0JgqndBodnPB8UVreeMmNqS7vdSuoXW9+6BLffBG7rKxvPFKUkszlqAmJtHiAYBzy4UvF2dw4JorHrxm//DKWhnhNX45ICtYqUvXmONRA+xJBLp0C1zn24Ds+wzkMfl+yVgnn80V/R8I91V56w/Cs8sEybdmDaGxrcWFWgLrMtQ7T8n4hspcT7T7Nm++5l921CfvBmLNNwayjf9wSAy2HXZvacQMV0ZWs4FR+7HS4i6whpQ2Qe4//BPlbARIp9ZHcnia/Z1cAdQyysQfrAWhhA==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEB2DeJZUvNZp7GSgqfL1qKHfjLPWKwbV2V/He+USb74ZWcdwv2C4sTeH60PEagBrFPnBLotMqjtkG1bzrj7eKOZE4CR+eTb4Ju7LH1nJL5HSEN5tid1+o4MEz0Uc9ip3NFBbLV97k8qFS/5sZlbHdx21/dIdyRSxwJ1YVDNfV1Jp99D/XBa00yCQH4IAd6pkYdU76J3Cqa1in4SJKzTruuFFX65nTu6xtrRZ3VnByH/pz+xOLK5WUZJcqD/NVWocaTowZVRfR5WMMPCG+CV/+BBuLMLmCLBuT8AnGczjG5oexMnvTLfUyNmnrunl77et1UHlnzEvMsgQKcYzCOtok0pxMp010OA/H0hs4UeBVhl4UYxW3mLQjED3Fd1wZeR7iGXRjkwVys5/kZPQY8vLvK1A==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>42fd23bc-6706-5d6c-bfc3-76731afe6c83</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:35:20 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153520Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=5ea419fade9dd31d07cdf2d390288bc85e41369755ba44e2e36a901030b2cd4a
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - ddeb6c21-2270-55a8-962f-39ee5f882409
+      Date:
+      - Thu, 15 Aug 2019 15:35:20 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEBvPDZ45GkZVpbiABNhJfTr4KOgSF11pYlOa3Qrx1qWpoau986m+6xReuOKc/zwOTkoRk/hfOUV8A8YIXWDD2cH0oL+X9VfJW5lbq71sKhlL2Ocro32ykmxMQ1xKQYL6bdCvCwI4K1FdnLdiNBzDV0hCkItCxhx4Y2OuM0a1B2ii5xQAiG5Ku2eoAxNGfLzVlS6tMQ+ckR2sgD6bR3dOedR2jCKXRkQVdNnBzCJ53BAOijFKK0ZZkewnf/aC0APzOHVbEE42NnEWGXVsGPau6wg4oWSsoe26LX3Cp6pjkhP1Tguq2q8Ohyc07VIaJ1R3OGxz3gQyuUZeDqAJJtZ7lP4o0QNhEByOH5JTCnX+B09XTwfTOi818MS6vhwhBlCPL95r339+4yR7EvGT1rB0LjpQ==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>ddeb6c21-2270-55a8-962f-39ee5f882409</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:35:21 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153521Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=80dc36c1d78f0a49d8c6b55ad620282d184a24626aea3a4dc44879bd79c8d303
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2fb84287-8070-5a5d-bdd1-1748fd89492f
+      Date:
+      - Thu, 15 Aug 2019 15:35:21 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3989'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>6612839c-7d07-44fa-a6cd-bb11bd0ecc47</MessageId><ReceiptHandle>AQEBdB5DvFsEa4YjMzoK77wHZOf57Bv/i1oUhYmPq6r1n1QYImcy/yJwAv50+lxldS7n7NHdj+FFk3APfRhGSRxDwzqh8zL8VtxSpr3PmHhzvPwaFqO3f2qTsmtTHG2aFTxmZ+fO/q+ezdV/llCCrhzr5zmmuViO+LwMFIotsIF9gVPvlIof4KwKfYo2nyYYoLZsQloZER989dZDZunUKMNLIgQAeQ/2CmWhDc7cpdFbU35uaZh9D08wg8ZlTbB08AD1mTJ5LCqMcLa6KsusRDFSV5SgDGs+owkE+p4dwByHJngJ+DGFF4t/HBL6Fhj7xVkJqcnn/1/L0ElUGheca6WOfvERCzfcL4sNoKxZchHEJUP+8yaZsvtRpu3OsbJ1WMVhbt3o4hAgjUXoiarmcg4GsQ==</ReceiptHandle><MD5OfBody>ed9b2f7997b19da495097eef80f12f86</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;4cd047b5-bc63-432c-97a4-1201a25b689d&quot; MessageDate=&quot;2019-08-12T16:13:18.2425253Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_2041_20190812_121251435.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>216a7edf-2e6c-457e-900d-aa1826b70e3d</MessageId><ReceiptHandle>AQEBN71pJe5jE+H+u5yBaENM780hPrwVyr7pce7LI5zVSnqlIB0TUyY3z9dVYK/Wmw7tVG3bx19n2xkGTfjtbTQpsIkmfURm84wfYLiphWGERyrLCqQVBxK8DHpOXdXOPKCCRuOquBIBFrw1RszESWjj9AwCfSdw0ayIoq+RIMfEVzsSBwFxZgSQNF1LavELwZf25gURwg22H/g3Ntr/sQVNqhDs5cXL63PFZWZvq+mkH05nsW2zhEorBAUVbY2FyacP+T+nMntkSgCjsxCIe9EKi3nQC5fJorxQNKjzTL+2GTZ8wsuxrbh7pPKdouvi2Ya0yjFBTBFRdu9QdwvBa+D865OVuKcxGn+pVm1P+Gzneqd+jrzRamAvdxIbw2ZfZiWtX0OCPzOmMULprwbhnNyFBg==</ReceiptHandle><MD5OfBody>321287f17e4e8212f47671b25c9eca85</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;820a637d-1faa-4631-8387-34817b21543c&quot; MessageDate=&quot;2019-08-12T16:10:15.8030041Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192152_20190812_121015161.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>8c42dfb7-940a-49f7-9014-75b74ae1ea43</MessageId><ReceiptHandle>AQEBJz6enbIk23Oq01O/kOONhSfojfR2wG/HWECqc2SI2zvBZEMvU8U1uLH/mjPPgow2Ioj5au1yn9hzUUwwCSJCWd6wVE7Gahq9DCmv6+K3wdpqInU6+iNOYIKWCMCNRlw94ds+l/ONv+FfK6SwxaZ0YJHn+sziHDqq0qG6WM+oqqnWMZOwmL781Ro7jQLC/G4CnbY72T8dV/ZhcooOi2hDc4cGV7dwrVnBD7N7Ibf6jjEIagwgIGeYDoKBw77Iw1GztkhgbPEZoApPET4H7C48qSY08UFgyYCLstiL7FUAh/lFWRDgCbrK/aTuOMtK0MFgnLcDvUOJxUwZdcVhZhfmDuJWs5n0+lyueJK2mgOp7qhky9XW6H776hpFbGecqAiRjz/W+9D8iF5ZnOk2OknIJg==</ReceiptHandle><MD5OfBody>23fc1dc8779e004d5d92a9986c0bbb16</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;
+        xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;ABC123&quot;
+        MessageDate=&quot;2019-08-06T14:58:11.5577988Z&quot; DocumentType=&quot;ShipmentOrderResult&quot;
+        ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot;
+        DocumentName=&quot;SoResultV2_<client_id>_R494571063-H13042707831_20190806_105849697.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;
+          &lt;Extension /&gt;
+        &lt;/EventMessage&gt;
+        </Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>2fb84287-8070-5a5d-bdd1-1748fd89492f</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:35:21 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153521Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=80dc36c1d78f0a49d8c6b55ad620282d184a24626aea3a4dc44879bd79c8d303
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 6525bc4a-b1d6-5422-9573-e985cc2f11d1
+      Date:
+      - Thu, 15 Aug 2019 15:35:21 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1514'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>0146b7fb-269b-4869-b76b-cf7fc5b15213</MessageId><ReceiptHandle>AQEBPWdeq7F3DxkQ8Nhq3wTCHZ32qRQ/4KmakHkiAn4eLnmzprcOVsJT3eASw60/BBkNDv/lZwTy/iJ4isNoLAVkFdhlKj8G5dYSI1YZnYagfNZbfyYjJYgqOJdDbYiHUISRj7bpvDtx3raLiHKN2I7pOuF+3xpMg7rpclRosgfcoB7LLOa/CGwA/O0esrwz5HlawlDrmIwq1qb9HfHYYTxaL9niGiY42lafgksODKQlO3Mcf77v9OKm7HDikZz4voil7lMuZarJAqjNGDuzvR75vmJ0iwsdccGpmJhKdExyhVTcEZoWtrEB+cGBnzEIE1YoiXuUty9EUjCk/opybHCa8pBLJ447mV3jcAi4vF66LEmIjC0T1hn1nuD3WNxhhCwz6aQ10amjv6i95ncl9Sv01w==</ReceiptHandle><MD5OfBody>03d64ef67c619693776721d2d0b6ad29</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;e80c469d-e292-4868-9764-d13ef6c85c21&quot; MessageDate=&quot;2019-08-12T16:11:46.5609295Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192155_20190812_121140070.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>6525bc4a-b1d6-5422-9573-e985cc2f11d1</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:35:21 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_does_not_delete_messages_with_delete_message_set_to_0/returns_200_shipment_object.yml
+++ b/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_does_not_delete_messages_with_delete_message_set_to_0/returns_200_shipment_object.yml
@@ -1,0 +1,484 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152829Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=6e7b04622bf29269816d626d0d4ad9d51fa6e239a2b90737d8f2f774777c36ec
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 07aa8a84-f7b4-5b7c-9855-df4b8bea4aed
+      Date:
+      - Thu, 15 Aug 2019 15:28:30 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEBHjFaogU0pAvHb+0zCbNf6p6MSJGg61U5JUrFEcWFPlBk+jPPoQqJP+s2zywYZT02FzCB2cWAJ2D5dlS+rftgOp9Be3oNOAd8N7S+r67UtZtGrRFvhurlkSPnapu0MBD/wlAat4MGSsuOy2ozC1EovLiLJtxX/HHaIuHaxvmJj9vQ+O2H+2/Spi3kOxeoD8+0KkrAvxPERExWulQfQa2cNj5X5gwCgpNzV6wVYFmGx9161l8T8SoI9L9bMQCS5nfC4lPv4vLBL17A+iGCzl29HNlw3/L52F5Hnr+GX1mjaMt0bsUltXMcJE3eeF3rGPu2QYTCO0sqiYdUC3VY5rfuAgtpxzOGtYRpiqtOXD2XHfEeh3cH2v7jsRgktkmInAiKMsRCdjDD22psSvTMOifwVQ==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEB+sWgCrFWF8yZZa3fhaAp/iWUAk4Al/OZJhXqpVH3dsCXVqft3XKfs/ak/k9mH4/tlkxGxBI0JThROZuYnDN/I754vcvyfBS/zj2gI7kfP1swfpMBEMJyZM360OQy28yu/rmkTuluCpJcR4EYUutoSie9E4g0weVnA2rf+aNqfxgyWx2b9g9H2czIbnIlkVyGrPOt0kmq2ZgHyDBypGUbKtvfmrQpT3+UCebWWUUAHh9nnyd74ZArQY3kWO6KeGtYYgAnES5lugqrWzLi9yeNGTInHYsmtjYOQzH7++KsRvJaozNIg7eNdv+jb8yYvU3OdIuiXJVXzMFyOn+AfdP+qckeviuTk6KNO99okW/gWZwWwSQnmDyt7wKuDQu7mt1d7Ig31PvvA8ZjdrSZEx4+bw==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>07aa8a84-f7b4-5b7c-9855-df4b8bea4aed</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:28:30 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152830Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=862609718ded57514f1dd27a5f99afec41e9979a7d4c812fcca68e4e754550a4
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 25058b5d-3107-5264-8fa0-de924d59de17
+      Date:
+      - Thu, 15 Aug 2019 15:28:30 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3989'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>6612839c-7d07-44fa-a6cd-bb11bd0ecc47</MessageId><ReceiptHandle>AQEBiXvboEySu5KY8j4Isxa2zm4rMSm20wovUqHT/0QMNVzy9Vtbk7FvTSeJTJH8hwY2hrW31TnUuEdi88/x/8lUa4fvHmyBYxsMIOLcGeWrBvZYjT61NO0QLXLGqR2zLFscBiOcrUeLLFrIXWCmyk1vc4KFs8BpYTXbYEnLS5w9WU6rjpxLsVXAv9+Y77VaQ2K0EnAkk3yXG24rIuBYzlhUGhJn+yrgjamZhlEVtmD3GZHJNK7wsE8dwi66MAg2OvwH8sMpM/0aAe2avEtNi3MMVFPnIEGRlZN91vJD64rMW09hvTaq4dE2dC5tvajG4r1Vz6f9yVsISfndOew/yxFtm2c5gTqT6XGprjMuXhz0nPPJ2YUgwRFvxcT/LOnptUUiN7/wRWHAdQVWFYbXQAse9A==</ReceiptHandle><MD5OfBody>ed9b2f7997b19da495097eef80f12f86</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;4cd047b5-bc63-432c-97a4-1201a25b689d&quot; MessageDate=&quot;2019-08-12T16:13:18.2425253Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_2041_20190812_121251435.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>216a7edf-2e6c-457e-900d-aa1826b70e3d</MessageId><ReceiptHandle>AQEBy8tL9/8pZWVn7HiwFDtzNiH0eVjC5xSGqvpVZ1/9Nms+JE9OsNOhalQDmrpQdRzS6rkfK2me90zmTflYcTG3o3xYIoG4KzrW4XKW3FVBlId9deqUZaHRHE4TBLiv5kIkJEALwHvAR5zoehfR4igvkz5H+U0uBUIFtW8JnK3Y/ehmfkf2JQ3l1g33w5sNvEHUBEFVLTAN/AeyOo71KL2CZhwsxjgFZwOyoUF8/O9VXO4LzWqQHqDYDZg92BwB6ud5gZpx/77f3H41Sf+bqmMjgYUKiV6kS/j8lpOj8QfmSNj1WfB4i8fLAdbb+gF2aev/HH556PtkCHH3T+jnPTV6kcMtuSo2CvZZpgfYuIHRNk20Qik75qIQPNrcG8+6a1TWQE5S6zBWX9c0qUGpLGj2LA==</ReceiptHandle><MD5OfBody>321287f17e4e8212f47671b25c9eca85</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;820a637d-1faa-4631-8387-34817b21543c&quot; MessageDate=&quot;2019-08-12T16:10:15.8030041Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192152_20190812_121015161.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>8c42dfb7-940a-49f7-9014-75b74ae1ea43</MessageId><ReceiptHandle>AQEBae1ss1KLKQUV5OF0EGRLfi6AcMl5/cP5nYEimqSqoSp2joqOAGJN4+hd/NXfDOQgfoXYyRBrujmVBGotVSy27tZCY+dIYtzbwPDnGPBS9rQAKNuT1MB8Hj5ihcxCqSj95kEfrrmFWDdivTYdw+2QMXha1fPTpPenLZm0hTmzorqAQoj5kA0bKv2AxWzPnoDSjpGIMOay7RjratNHxkTq6nU5WvCGrfNDEzoiQn71GxIDDNz2HdILnNRbMHveq4hLV8bx0ai4uvVRRUChHtqqqxdUulIoyD0H8BoZghKJyX9vtKwhrC7LBQZDg+AQj5KwrSDIC5diL132XhHHkSBbJS4JQ6zB2ZTk4GeUgkPs54UrHVVROLJ74Uzj0/JbpIrtu1Aoe1l2t5YiZMkYMYZ8sQ==</ReceiptHandle><MD5OfBody>23fc1dc8779e004d5d92a9986c0bbb16</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;
+        xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;ABC123&quot;
+        MessageDate=&quot;2019-08-06T14:58:11.5577988Z&quot; DocumentType=&quot;ShipmentOrderResult&quot;
+        ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot;
+        DocumentName=&quot;SoResultV2_<client_id>_R494571063-H13042707831_20190806_105849697.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;
+          &lt;Extension /&gt;
+        &lt;/EventMessage&gt;
+        </Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>25058b5d-3107-5264-8fa0-de924d59de17</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:28:30 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152830Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=862609718ded57514f1dd27a5f99afec41e9979a7d4c812fcca68e4e754550a4
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - c3b938e8-5234-5dfe-ba1b-6d272e6a7903
+      Date:
+      - Thu, 15 Aug 2019 15:28:30 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEBDs49eABBzizINGAquRljJMx7nBGZzEdf9P/OE542wD/CVlHtUID9Ie8VhZWL6AkTFZQCXbhxCsSsEqtupedF3wuR+D7RPRirtXZLPeTYZsvVW+3Iq82PXfJg50VEpAxpML+gdqtLbq7kBNSmVcSz4tegx3nhMiZ0/Xb+a/cW9AD1JJhI7McbZSSolW9gu3cJmD8yK7+dMirTLvy5Mo5tZxqAMVTaWaTHHtKDmMEx25CtjsE2gmziFeV1JubKNIcjtt824jOhbLn06p2wJa8yWP3bqzLK8fyo72rVZEaJwqxQi8rxhGxyOyYJeg+it5LxCZY6TxeIZythU0cO3TMeCk3KDAFhD68dD/I7gFeOWBsuJpsSkXVUHEFQmo3vxeGVISElW91sWaTS3Kbca/H4ug==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>c3b938e8-5234-5dfe-ba1b-6d272e6a7903</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:28:30 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152830Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=862609718ded57514f1dd27a5f99afec41e9979a7d4c812fcca68e4e754550a4
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - a21f112e-e384-5525-86ef-44e19fdb8951
+      Date:
+      - Thu, 15 Aug 2019 15:28:31 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1531'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c9e80ebc-7b96-4810-aba5-d129387d1a00</MessageId><ReceiptHandle>AQEBgrojR4xn4QKlM28/i2vVK5XW/Rx3nDc8euOPGqR+tytnFv2jUZ2foIo5BK60mYwJ1aXt5GqDAfo8rokQwmRAsi0+xhllJVV/1ZIBQsY08qAT62/tM1i8h6QOTkhoxzYwMM1se8codG/hotTn5VCN+PiqMkVzh0B0heYHaGr+ZfPbHsed4sIYDJBcNLV65JnkMm2BW2pQZ+7jh++Zi4+9K59q1NI26Ju4GJ/9vS6gk3WsQHDqnFsQlYnaykTDeSANjqiXaxkVOkOrtN9muy1qH5YpRnzZktSdqOLP3Aka0dbODVBhrnN3rFfLK7ai3AvEPgAeOTy/9iWgq1+LpU2NxI0KNTDCKOF+ngHVFleIyWx1HH28KbfjbLg8NG4N6lLZejioojD/J7cM7Zw7NXK/3g==</ReceiptHandle><MD5OfBody>a9dd99bd8641a19b3df3b90bf410d277</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;6b9f2760-9759-4057-8aa0-da00bea51af8&quot; MessageDate=&quot;2019-08-12T16:12:48.0434895Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>a21f112e-e384-5525-86ef-44e19fdb8951</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:28:31 GMT
+- request:
+    method: get
+    uri: https://<ql_incoming_bucket>.s3.amazonaws.com/SoResultV2_<client_id>_192153_20190812_121125472.xml
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-s3/1.21.0
+      Host:
+      - "<ql_incoming_bucket>.s3.amazonaws.com"
+      X-Amz-Date:
+      - 20190815T152831Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c6d3fc67c6fbaa924e1f6348cf4c1eea76c1c8de5956505883b0c8da2ff7f1b2
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - z1LlkSvScvw4FTyD2nhIlqEvN9b4Ws9PrNOP0XYZLKCbTFl0s4/ce2hAD9Ve9/xG7SMS7rJ8fPM=
+      X-Amz-Request-Id:
+      - A59294168FC4047A
+      Date:
+      - Thu, 15 Aug 2019 15:28:32 GMT
+      Last-Modified:
+      - Mon, 12 Aug 2019 16:11:47 GMT
+      X-Amz-Expiration:
+      - expiry-date="Tue, 27 Aug 2019 00:00:00 GMT", rule-id="OTZjMjUwZTctMDJiYi00NWFkLTgxNGYtM2UxYzQ1MzNhMGVl"
+      Etag:
+      - '"e4fc318459dc12fc6f0136058dcb4dab"'
+      X-Amz-Meta-Title:
+      - SoResultV2_<client_id>_192153_20190812_121125472.xml
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '996'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<SOResult xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ClientID=\"<client_id>\"
+        BusinessUnit=\"<client_id>\" OrderNumber=\"192153\" DateShipped=\"1980-01-01T05:00:00Z\"
+        FreightCost=\"0\" CartonCount=\"1\" Warehouse=\"DVN\" xmlns=\"http://schemas.quiettechnology.com/V2/SOResultDocument.xsd\">\r\n
+        \ <Line Line=\"1\" ItemNumber=\"M01S89-GHSPL\" Quantity=\"1\" ExceptionCode=\"\"
+        Tax=\"0\" Total=\"24.0000\" SubstitutedItem=\"\" />\r\n  <Line Line=\"2\"
+        ItemNumber=\"M01B86-SMDB-M\" Quantity=\"1\" ExceptionCode=\"\" Tax=\"0\" Total=\"24.0000\"
+        SubstitutedItem=\"\" />\r\n  <Carton CartonId=\"S99192153-2019081211\" TrackingId=\"1Z1006881330002019081211\"
+        Carrier=\"USPS\" CartonNumber=\"1\" ServiceLevel=\"FIRST\" Weight=\"1.2\"
+        FreightCost=\"3.05\" HandlingFee=\"0\" Surcharge=\"0\">\r\n    <Content Line=\"1\"
+        ItemNumber=\"M01S89-GHSPL\" Quantity=\"1\" />\r\n    <Content Line=\"2\" ItemNumber=\"M01B86-SMDB-M\"
+        Quantity=\"1\" />\r\n  </Carton>\r\n  <Extension>192153</Extension>\r\n</SOResult>"
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:28:31 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152901Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=6792df4bfe015f66028685694486c9bf03de0726dc75a357598761e226a77e7c
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - '095f5ead-d8f7-5440-83fe-0b62a489f115'
+      Date:
+      - Thu, 15 Aug 2019 15:29:02 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1514'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>0146b7fb-269b-4869-b76b-cf7fc5b15213</MessageId><ReceiptHandle>AQEBGS/SimYo82rz0g0v3e8BU+rMwIcdM9AR0qkMxmofqWXnzkxjTbrjoI2XEQPaF6XmUgB/K5OOuIwqvWAaYHiK8kTfIynk2TNpuiPXTAAPfOF7jRLF6+PfobFEcw8tw8X2HWuWCvK0clD503RkYZpxBn0EW23NsKU2EfparUrvShtVXcLjdEBZzG32PxwPU8uTPXxsaUUdERQ3XVUUQv0rxa4C4kQ7fiiaLwMwzTtO69C6JSV5Qu2mgq7ZM2S+4C3IcAUNDYMSWhFif3AB7N/OweRlbdIbRpaCRr951JISnhlv7CmcH9sGKbzbEX7gEH8k8ejUxTxXIRUSH9FTue83a96ONROuPV7kQMKPIVUGB7D+C4o+oqYL42mLQhLXR9GkJbVWk4Y1Y6SPId4X+zztyA==</ReceiptHandle><MD5OfBody>03d64ef67c619693776721d2d0b6ad29</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;e80c469d-e292-4868-9764-d13ef6c85c21&quot; MessageDate=&quot;2019-08-12T16:11:46.5609295Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192155_20190812_121140070.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>095f5ead-d8f7-5440-83fe-0b62a489f115</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:29:02 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152902Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=16acf640230ac560b7be774c7ab205a1ca6f8a518ce736152e4f039b8ca490ed
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 6290d91d-8be2-54dc-b562-8cd2f79cd263
+      Date:
+      - Thu, 15 Aug 2019 15:29:02 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3989'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>6612839c-7d07-44fa-a6cd-bb11bd0ecc47</MessageId><ReceiptHandle>AQEBJx15Lm7NrQcuh2/Xb7M7ecgXKniPBcR2Vv3KeJpL2GYhEAgsO6DG10oB2aL3W5Q/gjp/sDhoYBYcKvj1xFtnN12F0fsilSxF/ojHwVns2VmSf+nS1bhvEl9tHpI6jSjZMzXFFgCi2PaqtxKBGXmkJrPGRTKMw/J5+7HTwCOqD9S291LFuWlFKT/rLYOJsG/ZXJJfhFwV2eh+D2bHFNUI6bsFMu4vL0nuA1ZnuKtkv+On6k7jTKmdfqvnCDoOcZ6poFaG6K1OpdPKBdzQ8FLQoMm9FqnuSrxt4k/UVqGjbi1Wl4ZklWVRRRZVt2WGsWcfsF8y029cPsPrHG7vb2D+K4E0oM7KgxN4TEZGmeVs6Q8t7D6ZBXEpQquADVfG9qP1wF3+vL1jzBcOG2SYzud4jQ==</ReceiptHandle><MD5OfBody>ed9b2f7997b19da495097eef80f12f86</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;4cd047b5-bc63-432c-97a4-1201a25b689d&quot; MessageDate=&quot;2019-08-12T16:13:18.2425253Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_2041_20190812_121251435.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>216a7edf-2e6c-457e-900d-aa1826b70e3d</MessageId><ReceiptHandle>AQEBay+vSQzclsedYvc6jM6IddYnCxicZJ34Rm4ok6PPV9crIC/6q9RXYGJcoYwlz72vuA5QRFNY3f+LqaXaiBPwpFptKAFMdbjgAgR0n0K5aaY2jdD7FeDt/ujj5VUV31nunlDMX/Ao82JQ2rPG8iAu1w6YCjIuVu1aY1b4kdrOccRqmqxSGMSTa0yGESaBkGSmnhMIAeaCpr44VHssxVWhsKqyCmrXIxAEQV8u8cLstUROKWx7hSDZ4/94RIaEbHAXV2KE4aONPGBuoaARVfeqzSKpM+hX/MJvHknJf7ccU0RoyW5/415JSwTMOkNp0J5/JbRLkNTy4/uH1Sma5rqTeYQFCOq8X0o6VYyY5d/R+VZJDl2uNkHcEzdROFffa/5WacJeLgRrq2MkPkhWZVn1zA==</ReceiptHandle><MD5OfBody>321287f17e4e8212f47671b25c9eca85</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;820a637d-1faa-4631-8387-34817b21543c&quot; MessageDate=&quot;2019-08-12T16:10:15.8030041Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192152_20190812_121015161.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>8c42dfb7-940a-49f7-9014-75b74ae1ea43</MessageId><ReceiptHandle>AQEBeX29ahG87x4Cugz8YfbnWISIsq446aUEtjFeX2UXuoLS0k9z6P0pBGZX9XROKAVullvQjRMJoqEIjpPN52CqFVzoAhhA2ZKILpn0+JxZ5qiPpiNGn87aVIbfOBIO8Yd9g7emx3MxuYTlTkbq2FtbFznu2PCVK+MOjXQrICyeRDL4pRdDFyyNpuDxYrbpIisx8+ogByvIlfZ1/cvuQBnK/H3WOhOVlx/GfUWP4f7NeH1RXYGJpDnGj6JBml1F65vFY7cmNnek6WsM3S+b6OjfgIMwXlcFRX355FFTwGbhdiNW0rV5K3xXKdrR6tvV/NURt9bN0iYgaLoQRvceXMF6uCAbQWnJedmb6MdnN3Ul81/TgI3VMfOl084IOWilPVbTbKq3NXqGOoDtpLA/1FgcCw==</ReceiptHandle><MD5OfBody>23fc1dc8779e004d5d92a9986c0bbb16</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;
+        xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;ABC123&quot;
+        MessageDate=&quot;2019-08-06T14:58:11.5577988Z&quot; DocumentType=&quot;ShipmentOrderResult&quot;
+        ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot;
+        DocumentName=&quot;SoResultV2_<client_id>_R494571063-H13042707831_20190806_105849697.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;
+          &lt;Extension /&gt;
+        &lt;/EventMessage&gt;
+        </Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>6290d91d-8be2-54dc-b562-8cd2f79cd263</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:29:02 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152902Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=16acf640230ac560b7be774c7ab205a1ca6f8a518ce736152e4f039b8ca490ed
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - d4c66627-ae28-50e8-8839-33e8d257353f
+      Date:
+      - Thu, 15 Aug 2019 15:29:03 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEB8Stkt2z/rYr1rZcgvdkYsCAmm0vvu0SVUSld7pX0Vtl2VzKtlCavKNnuqZqPJR0/HTSR5FImCrfMVEsg358Ca33nBNCbdpadCix4zxoKBSgMsbwsM9Uim3LaoIxk81uc/p3cv0W3qgBFbAkjNqq//rwc4sp0TGbIfRELHWGa/haMrsLT+BYBb9iExgPlSOmdKt4fOmUUrpj/1i4s3+aFnT+WTGzkp/W7yMvvHhm5OoUFYiAtQKkayfzQRpYKSHhiBtWz4rBIfl1y76KH2ji0/1+YAb27CRJGQoz+ET5hTlTXCEO/dBcCjme4ne8REair9J5p+OkyAAZw18nluKflPnYtFY/yOiAIoVqMRZVPDrht0SSEPbGlKOEg3kByTeAiKgRrRT5T+9R95tYNTv4XTg==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>d4c66627-ae28-50e8-8839-33e8d257353f</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:29:03 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T152903Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=8b23e6bdcdebffb3377bf1c21d9dc5daf08c77a198e7f458de68c807a389efe0
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 1964201e-7e97-5e9b-a1d7-75d102e8040d
+      Date:
+      - Thu, 15 Aug 2019 15:29:03 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEB2zX5gh0T1fTwBIwJtJ8ccJwY5LdR74ggGTS3t7U9vODRpH8XR1Sf9/alJq2vDmWSdFNhgvX/DclYeIEG7sU40fcBjbA97EpNQ3MTv5GlMpMhivH++mU2kr4sOpssUraA+bhuiBhoOcwfbn8Bl7uz783odfuG0X94U+JYa4F+pd3Jyk99/6G6mrV7CQIAZ/UkbcgSZ9+rmq5HJEyRUUBWzluJqiow5D68bwiJ/rD01mL3Q0q6wuNakcZJShocQGbfQQqFV+E/J11Q4bq7Mp6/h2gyKAqVfHk8vXWe8PYr/cKHAYTh0AaZtPvKzxa+6piIT8+EIezEwmUtS1iyvQlB4+3BlKOMUbPDp4TLiJuDStr9rqlWyBj9Vtu08SMs0VN0gBOuPhz7BSxhSkq2kLrZZA==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEBZdznejTqd4ZtZF7NjqO6xjye5GvVHElkFjJMsuGOXwR9EvC7psof4H85tZj13LhJaBjTNRwTZoD9bKumWYwyFgiBF/l0J26DFmuUIkGRoozhnDtmiZYzOcX0KQgabQwQvmXILF1AQ12BgCIfcvgLUWtYdkBJ56cRm2H1dXbeEGXZsg+KZquwP1ulgf5rxvrzfoFCIUn70cHvI+o0ssyAqlZhK6zP76s5bW0vkTDArA05HOSd99VhWGHltetezsIB38n8LuTnXP3imnhi66KuGMLM6WXnASTcgpgY7NFkVPMic/bEAkT5lCwdh0AfREskrVBeMV8IIfEc79FiVALzg8cb9murXwjw4yqiDW/sqpiJv0M30NlgBLjXaGRA7UkKWO3J6qGbp3FtJKYBBwSatQ==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>1964201e-7e97-5e9b-a1d7-75d102e8040d</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:29:03 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_does_not_delete_messages_with_delete_message_set_to_0_integer/returns_200_shipment_object.yml
+++ b/spec/vcr/App/different_delete_message_scenarios_using_get_shipments/get_shipments_does_not_delete_messages_with_delete_message_set_to_0_integer/returns_200_shipment_object.yml
@@ -1,0 +1,482 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153047Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=18fa5dfd21162eb376e36ac1a033d5a0b5df7cce9881ef98ab76922fe7dccdbb
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 3e70b741-406d-5056-b9c2-e28e3c8a77ab
+      Date:
+      - Thu, 15 Aug 2019 15:30:47 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1531'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c9e80ebc-7b96-4810-aba5-d129387d1a00</MessageId><ReceiptHandle>AQEBp1Lc2Bw0jZpGbdtliiByk+5a/ukvUSXfUvEsqI+VkObaSoF1RS+ysZCTXpqZqo0NZnVgAGAltWEUAS6nYkPVyHhiL9idAaXiIc73AhHCJxvIOcqY4WQpTgQjBxg4GGXgkC+0dYxp51Ag4bfzgUmh5yRu1qDQXS/nOXvjCWTvnICbZyoxCAZzYeFIV7cFXFKi8t9w3VGVt8WPeb3jBindDpknHewZYyh6Hys6HPWIxWhaox3EnKbFXpR3J3uzKe+lrrkT1kqXi9i1ArOaWXNZpc7MuWNnR9NVr9noL+gZH+nRxYfSHdme9Jm+nQ7JlFai/03uRYE2gLxaJnml0XdpO7QGQx9ouITVQTOPYGOHAR9X/eOr1DjO7ObOfn70DlLKVQGsdtiw2MRSiKoKFAd7+w==</ReceiptHandle><MD5OfBody>a9dd99bd8641a19b3df3b90bf410d277</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;6b9f2760-9759-4057-8aa0-da00bea51af8&quot; MessageDate=&quot;2019-08-12T16:12:48.0434895Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>3e70b741-406d-5056-b9c2-e28e3c8a77ab</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:30:47 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153047Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=18fa5dfd21162eb376e36ac1a033d5a0b5df7cce9881ef98ab76922fe7dccdbb
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - a7e87b87-17c0-55b7-a3f0-2e486b2772f5
+      Date:
+      - Thu, 15 Aug 2019 15:30:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEBMqRNxmS+bAGN8gnB3frCZ+eOYDY3VcdDv/EfxPSWuo04bczXdzmlvqC95ayQJJZPLPqnh91feU613l7fsZuotCXw21jW9OM5TvpjP4ajBo1OM4n3wsKXEhYIzOy570aicN40+Q0oD/XysGsU2V4yvUxOgXQ0enp11IwaszOl/bHfST4BLgK96f9NWfsef1GToOzzuFdDV72mCHGXXQ3K4gzKyNP/F5iZFBZ5HNPNn5wROwn4rLxMw8mL3Ry6H4/spaKTGkF/b9QoivgBy1lFe7hcyV8FAo46iMVyRhm9z2G+UFt7iaSvc+OwkTf8Lzx4qSdGijUwd4H/SE5Lsl1r6eewLPrSpn5uQh6wSXmDVriov7AeEljwHvHOAgouHJ3N+s+HrzN1Ht6gLsqSiC09bg==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEB2mCvvO7mHlPfycfoiURR3LnFPssN1apKvBjnenjed8OVpkSbJV5+cstP7D4o1orf+klgczib6rNvyc/nC/ZpDbUNh645ofKulT5HYecCC+YMh4ucA2ySN9SisSSXX85UXSigvzj2fLK44BtdPWaBMFDr76x5qF93uTece9djO+Jf0zbxudR/QZ+PCzcTTb+DHxhfZgnEOImyvpaP3gJ5NegNEGBbqmKloY31Ql5IVIq4+az59unO9yOl5Q3STD2s2a/et8cyh52EXIx+bFv3xsVSlOIsDhZm6NXinOt1oqxF41Te25AbhBdOLkk4lGnB62CnARtlY+I/NDibSEyF+iMxBZBFNbxFypNGjghvwN6j7QN3PMVYoqD4TOu/A6w0RnsE9NPXlMvCq3qSsVI6kw==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>a7e87b87-17c0-55b7-a3f0-2e486b2772f5</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:30:48 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153048Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=40b09c04f642c7cc3956c20253fca1ee339b5f6efeb93be584f8a4e602d08aa6
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 0d333438-c4f1-5a0a-9cd0-61f7b8194d88
+      Date:
+      - Thu, 15 Aug 2019 15:30:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEBTq4QiSKzA1N5D/aKs5iO/YDzsfOacxXVuNVpW6n4WAkpwosLM6lKqUnZ+XYMNhQ43qKIX+9dQLJYp1HZpYLWrnO8kjjBp3TaMiIZz4kZmAHpPbmZGRCFxMQf/kxrDZiRB+FOMuW/GOYyJ4QBnXR9QIUzxtaZk/CX6c1wSJeCG5TILBQWrzAhuRn28d9yLHNLeHlrnHT2xMRk8bpjPi90cjPcDve2R6UdABwVMyLn0770Z8wOzoMlIeI2brAdKG2WK9mCGYIRuc75ON+7HeJAMG/1C/+1vXbfr/w3bxB5UyKvcLpLAktwNGHcjCHylYRKhQaNy6mxMGkiQEfhshyhcyevjem8Y6kIXlBkL+w2SQSo0pLT1oMcyOy/u7MFpNR46ONjSJlYjiMPBeHV4f2eEg==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>0d333438-c4f1-5a0a-9cd0-61f7b8194d88</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:30:48 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153048Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=40b09c04f642c7cc3956c20253fca1ee339b5f6efeb93be584f8a4e602d08aa6
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 4b05a401-5650-5b4d-8252-f1ce2ab8eefb
+      Date:
+      - Thu, 15 Aug 2019 15:30:48 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3989'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>6612839c-7d07-44fa-a6cd-bb11bd0ecc47</MessageId><ReceiptHandle>AQEBLEPY1uoyyW5Nv7lrpu7MPIoWoa5Gx2MQP9gILvE7LsMDwD8djI0cHxM/k51kQnYwXg4kW2OmKKWv77g+uWrKD50ZdOrq/qRdFIpytOrgY8TZ8cfBvvUgrrMSwhc5d+/jCTdqfYlH+oi4ViHfmJ9FtaUV1WlEE+97fxWPpsOKDWopN7UeaTbfPcu7d99f5/cOXSSyRpnEsG9PU08Mauz/L3bfzkNUEr5fRCcBkuD1ozuTeAku3H7uhAds/hRNhIqgW//R61IS1Zq8UX9o7EDjWyL+ZoKmpGTwvoGTSQjr+v7FxZx3eHQQZFA1k9KsNLZaCQm50cx99jeGrQ4g6tn+rI6L9yY9t+pxB03HxIBLLgoS2Jh3M8c8DPP2msGnz6RXq9aiGUpA7tb2H879ubAIfA==</ReceiptHandle><MD5OfBody>ed9b2f7997b19da495097eef80f12f86</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;4cd047b5-bc63-432c-97a4-1201a25b689d&quot; MessageDate=&quot;2019-08-12T16:13:18.2425253Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_2041_20190812_121251435.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>216a7edf-2e6c-457e-900d-aa1826b70e3d</MessageId><ReceiptHandle>AQEB0t/8g4/oANLdndmzrXxfIoA2CaUE05UwEPjj6/GyxY8VsuAS1AVyQODkh3AdWhbCwnw4JnKNq553dwkv8jwxb/TR/SSsTjhUNuXO15ISh375HVQsxPFuXjpDS9BTjq2R6r/FOTjPHLqK3HLWuxAgiF9XP/zS3NoEZ2k4RF7U6YwBauXHUYAzIUUzY2bZ2b4Wnht3EcVGr0eciEd8wtLVM9407fQcGg7aVRnB+yKGa5WipWUoIlYJx+vB+ZLX11RM9GgZWZH/LbCv+mOIK0uMV+k13saQFzXBiMBge+PZ0lGmnvY0Iq/vagfFBEFycFuOR/Q3u7uyDZseG2IWoJ1uH7uOAAQWuFpVZdRSSAQLbb+pewKlty6trOz50xMkSyqzRr24cKPwdydjdq6lv3VGew==</ReceiptHandle><MD5OfBody>321287f17e4e8212f47671b25c9eca85</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;820a637d-1faa-4631-8387-34817b21543c&quot; MessageDate=&quot;2019-08-12T16:10:15.8030041Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192152_20190812_121015161.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>8c42dfb7-940a-49f7-9014-75b74ae1ea43</MessageId><ReceiptHandle>AQEBl4JIekJrJOfo+HnMs5bwt8wvKNspYsA7UTyVmtuXtyE4bV5Lv24BHjqSL0819e0+7V4IKj+UfkJJTThbTUmPmLbNzOn2XQLhzZQ47Jh0LG2Sj5lN1eM0+U2LSDpCO03pEqGfi8HNOtfNFdma2mZAmmUeUn50Dq67gQYHBhg3YBTyWI3yuNwtFHz6s/QOTyrSZ/XTIvA3vRWHNBuYuv8eK9uDKijEE7g/xf+Cl9CX88nb8C4UN+xDPNrpGWcIaRtsQt8ceiBahk8LXIwisKhVeTLAHQk7GIG/2p7noD1DP+AGzD1FkyqCGtVdvdvdSLsJCpUSaWD+5dADPma243pUUrBa0+dP4oVx4TNW+zZgaWX8P1397xjyIrXSUzRFz2tEdVlLjdB+NcoxMCmi92YuEg==</ReceiptHandle><MD5OfBody>23fc1dc8779e004d5d92a9986c0bbb16</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;
+        xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;ABC123&quot;
+        MessageDate=&quot;2019-08-06T14:58:11.5577988Z&quot; DocumentType=&quot;ShipmentOrderResult&quot;
+        ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot;
+        DocumentName=&quot;SoResultV2_<client_id>_R494571063-H13042707831_20190806_105849697.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;
+          &lt;Extension /&gt;
+        &lt;/EventMessage&gt;
+        </Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>4b05a401-5650-5b4d-8252-f1ce2ab8eefb</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:30:48 GMT
+- request:
+    method: get
+    uri: https://<ql_incoming_bucket>.s3.amazonaws.com/SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-s3/1.21.0
+      Host:
+      - "<ql_incoming_bucket>.s3.amazonaws.com"
+      X-Amz-Date:
+      - 20190815T153049Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8b05fead34264af12dbf7b6529db6ab10369297f5096f5d5fbaf28ea6dfacc08
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - CjAVborsj/FWdrI5+EYLc7Q/ze4eGrULYi5dEfrUz+CcgoDq9X1WHHlVbMELxAHqSh3rUXR/yRQ=
+      X-Amz-Request-Id:
+      - A749A9B21DC37205
+      Date:
+      - Thu, 15 Aug 2019 15:30:50 GMT
+      Last-Modified:
+      - Mon, 12 Aug 2019 16:12:48 GMT
+      X-Amz-Expiration:
+      - expiry-date="Tue, 27 Aug 2019 00:00:00 GMT", rule-id="OTZjMjUwZTctMDJiYi00NWFkLTgxNGYtM2UxYzQ1MzNhMGVl"
+      Etag:
+      - '"4c126b4afdc055f277abb30a776b9eb7"'
+      X-Amz-Meta-Title:
+      - SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '827'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<SOResult xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ClientID=\"<client_id>\"
+        BusinessUnit=\"<client_id>\" OrderNumber=\"R712449277-H36307541617\" DateShipped=\"2019-08-05T14:07:00Z\"
+        FreightCost=\"0\" CartonCount=\"1\" Warehouse=\"DVN\" xmlns=\"http://schemas.quiettechnology.com/V2/SOResultDocument.xsd\">\r\n
+        \ <Line Line=\"1\" ItemNumber=\"M02B42-BNC-M\" Quantity=\"1\" ExceptionCode=\"\"
+        Tax=\"0\" Total=\"37.0000\" SubstitutedItem=\"\" />\r\n  <Carton CartonId=\"S99R712449277-H36307541617-2019081418\"
+        TrackingId=\"1Z1006881680002019081418\" Carrier=\"USPS\" CartonNumber=\"1\"
+        ServiceLevel=\"FIRST\" Weight=\"1.2\" FreightCost=\"3.05\" HandlingFee=\"0\"
+        Surcharge=\"0\">\r\n    <Content Line=\"1\" ItemNumber=\"M02B42-BNC-M\" Quantity=\"1\"
+        />\r\n  </Carton>\r\n  <Extension />\r\n</SOResult>"
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:30:49 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153119Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=13a1dc83a6d22b4e6f787b40d2d908f6dc72d79ac9a56290daffd3a794749068
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - d76d75f2-e14c-52bd-8e5e-203d9c446628
+      Date:
+      - Thu, 15 Aug 2019 15:31:20 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1531'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c9e80ebc-7b96-4810-aba5-d129387d1a00</MessageId><ReceiptHandle>AQEBs7DodUu7isU+z/jZ/zW5oPvqgV6ua/M3fwbHrBrrcu58wfHiCUe37JJQGvDrRE5k8XeYqc70Aq2iFjeBJHnM9avD50vA2CilQ7VjQ/vJB+cXAb+cr+zTu18RYXOq9/5OIrbhxu4aHnZILrgipGtIbHFUot0cg4CazXwdEeAwejVwrLjW7R1/Wl7wWMw7DbHt1dgEi32LJQ2h+sVY2lKy5OBmyS9UTJH485lve/t9UoyxQSKb8e8N8TnuPXYZ5/PsFwNjpfXndiBncwPB4g8n15s7Kkj6hQVkoEj4FBpS0R+dtjcakoRugLFiuHe5xt1AWEcyW8pPoQTgUGE1jhwMD1ihcQY3VcBwjre9zCi61kFTYnz6EYrHUjJ7bpIYZ2Ox4qzbG4QWBAVOUUxfarnKiQ==</ReceiptHandle><MD5OfBody>a9dd99bd8641a19b3df3b90bf410d277</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;6b9f2760-9759-4057-8aa0-da00bea51af8&quot; MessageDate=&quot;2019-08-12T16:12:48.0434895Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_R712449277-H36307541617_20190812_121233335.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>d76d75f2-e14c-52bd-8e5e-203d9c446628</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:31:20 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153120Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=e88d26802248133e24434b600cd9ddda9b2f79266d6ec62cbf43b3556400e47c
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 33d01755-1caa-59e3-9c29-429a61a20f1b
+      Date:
+      - Thu, 15 Aug 2019 15:31:20 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3989'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>6612839c-7d07-44fa-a6cd-bb11bd0ecc47</MessageId><ReceiptHandle>AQEBQcxQ8iLm8ZkyLhCxXwd3DAsIe+s8NdCOqm80UbbN/WoMYy0KhpWZtwBFadBW5dYZ1fFFRjLFW4gP7uljx0w4sZBNKgbL8HUvv+PBytP0+0ozNVjKu6D2IozYWCcEvzSKHGZr3MnDSrPXPZ+pmE1Uk06TgUOPlpCRSfEbqq2QWCtQUVRqbI3kgci209mfyccfg5mAiS9uBirXe5D9Tvzq9kkLrIR4XIM623NRdEtLNMyK9TbGzCL5624G8JzrdwBgp2m1wbeZmww68ersI4e+8B4Mzt+8UgY0cphGhPLL+y9E+p2aEtvIyAwIlPJFJd/giFrHHQfpy283w6qcxB9sugrBzu2kKY0pe98zjUEYjpTUzeauuNK6tW/vCGkJivG0d2AGBCyW0KttQURlTw8zOA==</ReceiptHandle><MD5OfBody>ed9b2f7997b19da495097eef80f12f86</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;4cd047b5-bc63-432c-97a4-1201a25b689d&quot; MessageDate=&quot;2019-08-12T16:13:18.2425253Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_2041_20190812_121251435.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>216a7edf-2e6c-457e-900d-aa1826b70e3d</MessageId><ReceiptHandle>AQEBf6bfpUkqiHJG9nV5VF4GTMdtKFJ66p1F5YDDZhnLgzQDRPdJQDkWZFQHEKwbI/llkOti6Y9NZt8F75O2Lw5+tooaHiO4/Np6E6vJG6q/9KyMjFdvLMtfM1vHgDY9dLSCSqTYDwyv0/HUER12celr0I3jRxI7NAxx7j2ScYzdgB/3nsWGi9VRtAFD3MufZav1jHDKTt+BaknbJ/8WNUu+DFVQFNfXklBC2weMOvooh2XJtIhTVXhjRNI0j3Zjc4mDQrp/EST3lJZIKWBzYP2qWkWL23Ebv9IDCnJAKjlWujVUYYRhq9mAIinEUPbSAvF+F8E/1H+gL+007/2cdsOxNgLbWZ2xBJfyTbzOiByJTAbGZxYi+vzKdzwf0Hf1FBhYVYDyaSb5vqoqD2D5q3ia9A==</ReceiptHandle><MD5OfBody>321287f17e4e8212f47671b25c9eca85</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;820a637d-1faa-4631-8387-34817b21543c&quot; MessageDate=&quot;2019-08-12T16:10:15.8030041Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192152_20190812_121015161.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>8c42dfb7-940a-49f7-9014-75b74ae1ea43</MessageId><ReceiptHandle>AQEBhLBGNXPmPGR4KRMNaxNr0rPBRxdP9nHD6JI3rdFWEpe/+u7Fmye0q7Y35KXdA+vDOb8wZiaVORwoNXoDbMZb6VPQeXIRxC85b8nnoABrN7TSkc9QFEMZkminkTxwJ93tGlszuyd9uuNELsUofbIcCq/wf4oS/4NL+9FTw0AmN72YchYAi+d6Uk6JC1d+zffFA+o+nWApq6027nyFTWI/WtoMLbTAC9eKJhmfKZMNiojmqPgMFsxyAe4vXX1Z0g/Xd6iYLnqVm4940S1KWEfrS/DsnBoVOoF4KyAYQLSZ3f1nEoYKUBj4A1bVs7aK4xZmIOweUmEWJMj4Pc4IX551aG71axQ0LdpVfkfcvBKW5dnHDg9GTXQPTVHfJgFaVAz17WizLrbbXglCwLO3jDBi4A==</ReceiptHandle><MD5OfBody>23fc1dc8779e004d5d92a9986c0bbb16</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;
+        xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;ABC123&quot;
+        MessageDate=&quot;2019-08-06T14:58:11.5577988Z&quot; DocumentType=&quot;ShipmentOrderResult&quot;
+        ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot;
+        DocumentName=&quot;SoResultV2_<client_id>_R494571063-H13042707831_20190806_105849697.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;
+          &lt;Extension /&gt;
+        &lt;/EventMessage&gt;
+        </Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>33d01755-1caa-59e3-9c29-429a61a20f1b</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:31:20 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153120Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=e88d26802248133e24434b600cd9ddda9b2f79266d6ec62cbf43b3556400e47c
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e0e7c95-87ed-5d2e-9fb4-295afae55701
+      Date:
+      - Thu, 15 Aug 2019 15:31:20 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1512'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>c25906ee-5073-496d-9748-2443211afdf7</MessageId><ReceiptHandle>AQEBxI/OxyFubOl1enAdEXn9jQRr7nwftWzeDbGke5lwrzbhqAvhqD0SPaHlsoaylCEDXILDhFekigTzTzqDDPJlQl3+dr4yKV2CFMgraEdnC+VbOJ831EGZTIEmDnzTbk4dTpc/ViHgxD4KVnr0fxF7fAn8/6g2bOoPRqD7W5yKPxP+KIvCPuuz5nFnhTONsjPVZsEnFjQzhqLUXlDcFhWoIo1yvFbY3gtGjJaHceyqMoSj2G+4PLUxeQG/i7t0lwqVV2MfTZij2kY4enEqTwMkmBnWSsRHLWBCQYSWSeX0+eUWDLf6Yc3wWl37XjdohEJngdvDXTKpUhwwNVd5JHpB54gsfolkkJrf98SucHoqKmb5c8eGXkE4Bjk+rfVO4rJdP/ZFjlgFOZ/ugjTk8HRiCw==</ReceiptHandle><MD5OfBody>431e06dffdf42aa1e66678413b7cf7c4</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;54d657fd-654b-4b47-8433-90566b627559&quot; MessageDate=&quot;2019-08-12T16:09:15.1307127Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_6125_20190812_120854601.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>2e0e7c95-87ed-5d2e-9fb4-295afae55701</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:31:20 GMT
+- request:
+    method: post
+    uri: https://sqs.<amazon_region>.amazonaws.com/630008457067/test_mackweldon_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.<amazon_region>.amazonaws.com%2F630008457067%2Ftest_mackweldon_from_quiet&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.30.0 ruby/2.3.3 x86_64-linux aws-sdk-sqs/1.7.0
+      Host:
+      - sqs.<amazon_region>.amazonaws.com
+      X-Amz-Date:
+      - 20190815T153120Z
+      X-Amz-Content-Sha256:
+      - e427658d6defb55f4327147fbd175571ca71f8eae322503a567cb602bd9930dc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<amazone_access_key>/20190815/<amazon_region>/sqs/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=e88d26802248133e24434b600cd9ddda9b2f79266d6ec62cbf43b3556400e47c
+      Content-Length:
+      - '158'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 8de8f5dc-1c94-54fb-93fe-a013619d27f9
+      Date:
+      - Thu, 15 Aug 2019 15:31:21 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2766'
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><MessageId>b365af76-3646-41be-983f-acd2b5da1e63</MessageId><ReceiptHandle>AQEB4XpfcDDrwB/Fd/odK0aHRlwf8zDSrlByc8Gs31vRhSVD+8Yw/9WVqTs6w3Sxs+NEtSxyyWlpOnmUDTYh3Xr25GQwrtxZivSChqlzrvm0AIRzikug4zQCdQviCnuVQGlTbYPBaXCR6sVMDEjzHZP+olzIliYdPxI+hWILNTdCYN1YjEnmEQfqnCcwtHBFo1AZ8tMUOkrYGGLeSlsH57bcoN03wH3MK03eTf2I0Ie+sBCWYaGww/8AlxUMY2XEd/Gr7Cn2qV0RZ4ZNBiv4v79vLjbsiNAVGuLZ2CldXWqZCTLlG85HETzTBVhP/8IpuVfAngBw9ndysUcXkwCyUWJ1CZ/wqhauJLQGaiyL6gAWv0rJftaG+agHU81Gn1vCMXZaHlidQVcDU6KMOVCbpSXCsw==</ReceiptHandle><MD5OfBody>23690c0d3b20dbd8a47e52a06c879579</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;62a2bb6b-37db-43ba-b971-a010505e0592&quot; MessageDate=&quot;2019-08-12T16:11:46.2708199Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192153_20190812_121125472.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message><Message><MessageId>1a7f5dd9-a25a-43f0-9643-6e0697e3f455</MessageId><ReceiptHandle>AQEB4EwU0TbB3/DnOcfoBk/RreS/MUB1PUHsJRPk5WKgwtZ9TGnJUIZLOEUwIJGr0Gnaicx/6tgjwKMDoKlteToySNEzEFv9tQZc/eNen4R8kTKFvKGpQL0VhNywhVmG7AXVtFXkb/QfQNV1fhzR3oUu5683kFp2sG14F6RRHsWh3aroVTnZ642iAcUyX1AKhOYLcGhcsnriGNqapPxTmQPMD8RBO9iCnV4kkbcaYuQkYcg9cNZSUDjFbg2nHCL5cBrKeTWFe/N2pd8WSCQOTiJS20lQhNB2fyw0RO1qD1q+pX6yZFuPhTVG18GSt7AXT+JgsCxOMLDs7enhXR2n+5OodOiksQ5qzff5ykErHNpJXnmlHH0PEnBleyxwygBwys9cRL0Lbd0xF9SrNBSyo+l9UA==</ReceiptHandle><MD5OfBody>f31dfa6bd055ab3d1289099bc87076c7</MD5OfBody><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; MessageId=&quot;131ac224-4ee4-44dd-ae28-5bd25ccdf49e&quot; MessageDate=&quot;2019-08-12T16:12:47.6810064Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;<client_id>&quot; BusinessUnit=&quot;<client_id>&quot; Warehouse=&quot;DVN&quot; DocumentName=&quot;SoResultV2_<client_id>_192160_20190812_121234765.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body></Message></ReceiveMessageResult><ResponseMetadata><RequestId>8de8f5dc-1c94-54fb-93fe-a013619d27f9</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Thu, 15 Aug 2019 15:31:21 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
- Add more spec scenarios to cover delete_message as a param and
integer.
- Also added a commented line for `sleep 30`. When creating new vcr
cassettes for those specs, it needs to be uncommented. Amazon sqs has a
visility timeout of 30 seconds and it won't return the message even if
it was deleted if prompted within 30 seconds