### PR TITLE
Update `/get_returns` to use `returns` key instead of default `rmas`

### DIFF
--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -266,7 +266,7 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
 
       if type == 'RMAResultDocument'
         data   = Processor.new(bucket).process_doc(msg)
-        add_object(data.type.to_sym, data.to_flowlink_hash)
+        add_object(:returns, data.to_flowlink_hash)
         message  = "Got RMAResult for #{msg['document_name']}"
       end
 


### PR DESCRIPTION
- Needed to use `returns` because `rmas` is not one of the default types
that flowlink saves when it receives from a send_data action