### PR TITLE
Add a nil check for `check_regex`

### DIFF
--- a/lib/documents/shipment_order.rb
+++ b/lib/documents/shipment_order.rb
@@ -143,6 +143,7 @@ module Documents
     end
 
     def check_regex(field)
+      return nil if field.nil?
       field.match /[^\u0000-\u007F]+/
     end
 


### PR DESCRIPTION
- Some fields like `address2` is not added to every shipment and its
better to return before it tries to match because it would raise a
`NilClassError`.
- If the field is nil, it wouldn't be added to the XML file since the
hash uses `.compact` so returning nil feels like a safe action