### PR TITLE
Change `check_regex` to allow up to 2 chars that can't be transliterated

### DIFF
--- a/lib/documents/shipment_order.rb
+++ b/lib/documents/shipment_order.rb
@@ -146,7 +146,8 @@ module Documents
 
     def check_regex(field)
       return nil if field.nil?
-      I18n.transliterate(field).match(/\?/)
+      transliterated_field = I18n.transliterate(field)
+      transliterated_field.scan(/\?/).count > 2 ? true : false
     end
 
     class MissingZipcode < StandardError


### PR DESCRIPTION
- The check_regex was too strict and was catching punctuation
characters. The point of the error checking was to catch addresses that
fully use chinese/japanases characters like "-ハーバーレジデンス". It
felt like loosening this check to allow for two punctuation marks that
might not be accepted by QL would still allow the address to be
readable.