### PR TITLE
Add ability to set order date in shipment order

### DIFF
--- a/lib/documents/shipment_order.rb
+++ b/lib/documents/shipment_order.rb
@@ -16,7 +16,7 @@ module Documents
       order_header = {
         'OrderNumber' => @shipment_number,
         'OrderType'   => @shipment['order_type'],
-        'OrderDate'   => DateTime.now.iso8601,
+        'OrderDate'   => @shipment['order_date'] || DateTime.now.iso8601,
         'Gift'        => @shipment['gift'] ? 'true' : 'false'
       }
 


### PR DESCRIPTION
When sending a backlog of orders, they would need the order date to figure out which one to prioritize.