### PR TITLE
Update shipment result to change the field for the order relationship

### DIFF
--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -28,13 +28,17 @@ module Documents
 
     attr_reader :type
 
-    def initialize(xml)
+    def initialize(xml, msg)
       @doc = Nokogiri::XML(xml)
       @type = :shipment
+      @message = msg
     end
 
     def to_flowlink_hash
       id = @doc.xpath('//@OrderNumber').first.text
+      relation = 'order_number'
+      relation = @message['ql_relationships'] if @message['ql_relationships']
+
       {
         id: id,
         quietlogistics_id: id,
@@ -48,10 +52,12 @@ module Documents
         shipped_at: @doc.xpath('//@DateShipped').first.text,
         tracking_company: @doc.xpath('//@Carrier').first.text,
         line_items: line_items_to_h,
-        order: { order_number: @doc.xpath('//@OrderNumber').first.text },
+        order: {
+          relation => @doc.xpath('//@OrderNumber').first.text
+        },
         relationships: [
           {
-            object: 'order', key: 'order_number'
+            object: 'order', key: relation
           }
         ]
       }

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -19,15 +19,15 @@ class Processor
     # to delete it.
     # downloader.delete_file(name)
 
-    parse_doc(type, data)
+    parse_doc(type, data, msg)
   end
 
   private
 
-  def parse_doc(type, data)
+  def parse_doc(type, data, msg)
     case type
     when 'ShipmentOrderResult'
-      Documents::ShipmentOrderResult.new(data)
+      Documents::ShipmentOrderResult.new(data, msg)
     when 'ShipmentOrderCancelReady'
       Documents::ShipmentOrderCancelReady.new(data)
     when 'PurchaseOrderReceipt'

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -50,13 +50,13 @@ module Documents
         </SOResult>
       XML
 
-      result = ShipmentOrderResult.new(xml)
+      result = ShipmentOrderResult.new(xml, {})
 
       expect(result.to_flowlink_hash).to eq(
         {
         :id =>"H13088556647",
         :quietlogistics_id=>"H13088556647",
-        :order_number=>"H13088556647",
+        :order_number => "H13088556647",
         :tracking_numbers=>["1Z1111111111111111", "1Z2222222222222222"],
         :shipping_method=>"GROUND", :warehouse=>"DVN", :status=>"shipped",
         :business_unit=>"BONOBOS", :shipped_at=>"2015-02-24T15:51:31.0953088Z",
@@ -66,7 +66,7 @@ module Documents
           {:carton_id=>"S11111111", :tracking_number=>"1Z1111111111111111", :product_id=>"2222222", :quantity=>1},
           {:carton_id=>"S22222222", :tracking_number=>"1Z2222222222222222", :product_id=>"3333333", :quantity=>1}
         ],
-        :order=>{:order_number=>"H13088556647"},
+        :order=>{'order_number' =>"H13088556647"},
         :relationships=>[{:object=>"order", :key=>"order_number"}]
         }
       )


### PR DESCRIPTION
- The relationship uses the `order_number` by default but can be changed
to `shopify_name` to use with orders that change the default name like
loop returns